### PR TITLE
[CI test] Use `attribute_names_for_serialization` only in activerecord 7.0.3 or…

### DIFF
--- a/lib/active_type/virtual_attributes.rb
+++ b/lib/active_type/virtual_attributes.rb
@@ -218,8 +218,11 @@ module ActiveType
       end
     end
 
-    def attribute_names
-      super + self.class._virtual_column_names
+    if ActiveRecord::VERSION::STRING >= '7.0.3'
+      def attribute_names_for_serialization
+        attribute_names + self.class._virtual_column_names
+      end
+      private :attribute_names_for_serialization
     end
 
     def changed?


### PR DESCRIPTION
… later

Fix https://github.com/makandra/active_type/issues/175